### PR TITLE
Caching for CAPI content, and the spreadsheet

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -25,6 +25,7 @@ libraryDependencies ++= Seq(
   "ch.qos.logback" % "logback-classic" % "1.4.5",
   "com.lihaoyi" %% "upickle" % "2.0.0",
   ("com.gu" %% "content-api-client-default" % "19.0.4").cross(CrossVersion.for3Use2_13),
+  "com.github.blemale" %% "scaffeine" % "5.2.1",
 
   "com.google.api-client" % "google-api-client" % "2.2.0",
   "com.google.apis" % "google-api-services-sheets" % "v4-rev20230227-2.0.0",

--- a/src/main/scala/com/theguardian/Caching.scala
+++ b/src/main/scala/com/theguardian/Caching.scala
@@ -1,0 +1,19 @@
+package com.theguardian
+
+import com.github.blemale.scaffeine.Scaffeine
+
+import scala.concurrent.duration.FiniteDuration
+
+object Caching {
+  extension [K, V](c: Scaffeine[K, V])
+    def expireBasedOnValue[K1 <: K, V1 <: V](cacheTimeForValue: V1 => FiniteDuration): Scaffeine[K1, V1] =
+      c.expireAfter[K1, V1](
+        create = { case (_, v) => cacheTimeForValue(v) },
+        update = { case (_, v, _) => cacheTimeForValue(v) },
+        read = {  case (_, _, currentDuration) => currentDuration }
+      ) // reading a record should not extend expiration time!
+
+  def cachingMissingResults[K, T](whenMissing: FiniteDuration, whenPresent: FiniteDuration): Scaffeine[K, Option[T]] =
+    Scaffeine().expireBasedOnValue[K, Option[T]](v => if (v.isDefined) whenPresent else whenMissing)
+
+}

--- a/src/main/scala/com/theguardian/capi/CapiContentCache.scala
+++ b/src/main/scala/com/theguardian/capi/CapiContentCache.scala
@@ -1,0 +1,31 @@
+package com.theguardian.capi
+
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+import com.gu.contentapi.client.ContentApiClient
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.{ItemQuery, SearchQuery}
+import com.theguardian.Caching
+import com.theguardian.Caching.cachingMissingResults
+
+import scala.concurrent.duration.{FiniteDuration, *}
+import scala.concurrent.{ExecutionContext, Future}
+
+
+
+class CapiContentCache(
+  contentApi: ContentApiClient,
+  modifyQuery: ItemQuery => ItemQuery
+)(implicit
+  ec: ExecutionContext
+) {
+
+  private def singleLoad(key: CapiId): Future[Option[Content]] = {
+    val itemQuery = modifyQuery(ItemQuery(key.value))
+    contentApi.getResponse(itemQuery).map(_.content)
+  }
+
+  val cache: AsyncLoadingCache[CapiId, Option[Content]] = cachingMissingResults(30.seconds, 2.hours)
+    .refreshAfterWrite(5.minutes) // asynchronously refresh when the key is requested and is over this age
+    .maximumSize(100000)
+    .buildAsyncFuture(singleLoad)
+}

--- a/src/main/scala/com/theguardian/capi/CapiId.scala
+++ b/src/main/scala/com/theguardian/capi/CapiId.scala
@@ -1,0 +1,20 @@
+package com.theguardian.capi
+
+import com.gu.contentapi.client.model.v1.Content
+import upickle.default.*
+
+case class CapiId(value: String) {
+  require(value.nonEmpty, s"Capi id is empty")
+
+  // the value _should_ be opaque, but as it's probably path-like, let's check we haven't got a
+  // slash at the start of it, like much Ophan code tends to have.
+  require(!value.startsWith("/"), s"Capi id must not start with a forward slash: $value")
+}
+
+object CapiId {
+  implicit val capiIdRW: ReadWriter[CapiId] = readwriter[String].bimap[CapiId](_.value, CapiId(_))
+
+  implicit class RichContent(content: Content) {
+    val capiId: CapiId = CapiId(content.id)
+  }
+}

--- a/src/main/scala/com/theguardian/content/rules/CLIMain.scala
+++ b/src/main/scala/com/theguardian/content/rules/CLIMain.scala
@@ -1,13 +1,15 @@
 package com.theguardian.content.rules
 
+import com.theguardian.capi.CapiId
+
 /**
  * This class isn't used in production, it's only for local testing.
  *
  * It's separate from the Lambda class because adding the scala.App
- * trait pull in scala.DelayedInit, which seems to lead to
+ * trait pulls in scala.DelayedInit, which seems to lead to
  * java.lang.NullPointerException errors when invoked as a Lambda -
  * vals are not initialised by the time we come to service the request?!
  */
 @main def main(capiId: String, spreadsheetId: String): Unit = {
-  println("Recommendation: " + Lambda.go(capiId, spreadsheetId))
+  println("Recommendation: " + Lambda.go(CapiId(capiId), spreadsheetId))
 }

--- a/src/main/scala/com/theguardian/content/rules/SpreadsheetRuleEngineService.scala
+++ b/src/main/scala/com/theguardian/content/rules/SpreadsheetRuleEngineService.scala
@@ -1,0 +1,42 @@
+package com.theguardian.content.rules
+
+import com.github.blemale.scaffeine.{AsyncLoadingCache, Scaffeine}
+import com.google.api.client.googleapis.json.GoogleJsonResponseException
+import com.gu.contentapi.client.ContentApiClient
+import com.gu.contentapi.client.model.v1.Content
+import com.gu.contentapi.client.model.{ItemQuery, SearchQuery}
+import com.theguardian.Caching
+import com.theguardian.Caching.cachingMissingResults
+import com.theguardian.content.rules.SpreadsheetService.rowDataFrom
+
+import scala.concurrent.duration.{FiniteDuration, *}
+import scala.concurrent.{ExecutionContext, Future}
+import model.*
+
+import scala.util.Failure
+
+case class SpreadsheetRuleEngine(
+  spreadsheetSummary: SpreadsheetSummary,
+  ruleEngine: RuleEngine
+)
+
+class SpreadsheetRuleEngineService(using ExecutionContext) {
+
+  val cache: AsyncLoadingCache[String, Option[SpreadsheetRuleEngine]] = cachingMissingResults(30.seconds, 2.hours)
+    .refreshAfterWrite(30.seconds) // asynchronously refresh when the key is requested and is over this age
+    .maximumSize(1000) // we probably don't expect more than 1000 different spreadsheets...!
+    .buildAsyncFuture(singleLoad)
+
+  private def singleLoad(spreadsheetId: String): Future[Option[SpreadsheetRuleEngine]] = (for {
+    spreadsheet <- SpreadsheetService.getSpreadsheet(spreadsheetId)
+  } yield {
+    val ruleEngine = RuleEngine.fromGrid(rowDataFrom(spreadsheet))
+    Some(SpreadsheetRuleEngine(SpreadsheetSummary.summaryFor(spreadsheet), ruleEngine))
+  }).recover {
+    case e: GoogleJsonResponseException =>
+      println(s"e.getDetails.getMessage=${e.getDetails.getMessage}")
+      None
+  }
+
+  def ruleEngineFor(spreadsheetId: String): Future[Option[SpreadsheetRuleEngine]] = cache.get(spreadsheetId)
+}

--- a/src/main/scala/com/theguardian/content/rules/model/RecommendationResponse.scala
+++ b/src/main/scala/com/theguardian/content/rules/model/RecommendationResponse.scala
@@ -1,0 +1,30 @@
+package com.theguardian.content.rules.model
+
+import com.gu.contentapi.client.model.v1.Content
+import com.theguardian.capi.CapiId
+import com.theguardian.capi.CapiId.*
+import upickle.default.{ReadWriter => RW, macroRW}
+import com.google.api.services.sheets.v4.model.Spreadsheet
+case class ContentSummary(id: CapiId, webTitle: String)
+
+object ContentSummary {
+  def summaryFor(content: Content): ContentSummary = ContentSummary(content.capiId, content.webTitle)
+}
+case class SpreadsheetSummary(title: String)
+
+object SpreadsheetSummary {
+  def summaryFor(spreadsheet: Spreadsheet): SpreadsheetSummary =
+    SpreadsheetSummary(spreadsheet.getProperties.getTitle)
+}
+
+object RecommendationResponse {
+  given RW[ContentSummary] = macroRW
+  given RW[SpreadsheetSummary] = macroRW
+  given RW[RecommendationResponse] = macroRW
+}
+
+case class RecommendationResponse(
+  content: Option[ContentSummary],
+  spreadsheet: Option[SpreadsheetSummary],
+  recommendations: Option[Seq[String]]
+)

--- a/src/main/scala/com/theguardian/content/rules/model/Rule.scala
+++ b/src/main/scala/com/theguardian/content/rules/model/Rule.scala
@@ -7,13 +7,8 @@ case class Rule(criteriaByName: Map[String, String], recommendation: String) {
     val inSection = criteriaByName.get("if-in-section").forall(requiredSection => content.sectionId.contains(requiredSection))
     val notInSection = criteriaByName.get("unless-in-section").forall(excludeSection => ! content.sectionId.contains(excludeSection))
     val hasTag = criteriaByName.get("if-has-any-tag-of").forall(requiredTags => content.tags.exists(tag => requiredTags.split(",").contains(tag.id)))
-    println("Content section " + content.sectionId)
-    println("Content tags " + content.tags.map(_.id).mkString(", "))
-    println(s"inSection $inSection NotInSection $notInSection hasTag $hasTag Recommendation $recommendation")
-    inSection &&
-      notInSection &&
-      hasTag
-    // if-has-any-tag-of	if-is-edition	unless-is-edition	if-in-section	unless-in-section
+
+    inSection && notInSection && hasTag
   }
 
 }
@@ -21,7 +16,6 @@ case class Rule(criteriaByName: Map[String, String], recommendation: String) {
 object Rule {
   def from(headerRow: Seq[String], ruleRow: Seq[String]): Option[Rule] = {
     val valuesByName = headerRow.zip(ruleRow).toMap.filter(! _._2.isBlank)
-    println(valuesByName)
     for {
       recommendation <- valuesByName.get("recommendation")
     } yield Rule(valuesByName, recommendation)


### PR DESCRIPTION
Note that the caching here is being applied separately against the CAPI content, and the spreadsheet, so you can, eg, ask lots of questions against a given spreadsheet for different bits of content, and the spreadsheet will only be fetched once.